### PR TITLE
fix THUCYDIDES-160 (no candidate steps found when path contains spaces)

### DIFF
--- a/src/main/java/net/thucydides/jbehave/ClassFinder.java
+++ b/src/main/java/net/thucydides/jbehave/ClassFinder.java
@@ -65,13 +65,23 @@ public class ClassFinder {
         List<File> dirs = new ArrayList<File>();
         while (resources.hasMoreElements()) {
             URL resource = resources.nextElement();
-            dirs.add(new File(resource.getFile()));
+            dirs.add(urlToFile(resource));
         }
         List<Class<?>> classes = Lists.newArrayList();
         for (File directory : dirs) {
             classes.addAll(findClasses(directory, packageName));
         }
         return classes;
+    }
+
+    private File urlToFile(final URL url) {
+        try {
+            return new File(
+                    url.toURI()
+            );
+        } catch (final Exception e) {
+            throw new RuntimeException("failed to convert URL [" + url + "] to File", e);
+        }
     }
 
 


### PR DESCRIPTION
The expression "new File(url.getFile())" is buggy because the result of
"url.getFile()" contains url-encoded characters (like "%20" instead of
space).
The fix is to use "new File(url.toURI())" instead, since that takes care
of decoding url-encoded characters.

See also: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4466485
